### PR TITLE
feat: add feature tour post

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -158,6 +158,13 @@ export default function (eleventyConfig) {
       if (data) data._adocAttrs = attrs;
       return attrs?.image || attrs?.cover || attrs?.hero || attrs?.thumbnail;
     },
+    date: (data) => {
+      if (data && data.date) return data.date;
+      const attrs = (data && data._adocAttrs) || readAdocAttrs(data);
+      if (data) data._adocAttrs = attrs;
+      const raw = attrs && (attrs["page-date"] || attrs.date || attrs.published);
+      return raw ? new Date(raw) : data && data.date;
+    },
     github: (data) => {
       if (data && (data.github || data.gh || data.githubUsername)) return data.github || data.gh || data.githubUsername;
       const attrs = (data && data._adocAttrs) || readAdocAttrs(data);
@@ -187,7 +194,10 @@ export default function (eleventyConfig) {
   eleventyConfig.addWatchTarget("public");
   // Custom collection for AsciiDoc posts
   eleventyConfig.addCollection("adoc", function(collectionApi) {
-    return collectionApi.getFilteredByGlob("src/posts/**/*.adoc");
+    return collectionApi
+      .getFilteredByGlob("src/posts/**/*.adoc")
+      .sort((a, b) => a.date - b.date)
+      .reverse(); // newest first
   });
 
   // Local-only API to read/write config.json when running `npm run dev`

--- a/api/ping.js
+++ b/api/ping.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ ok: true });
+}

--- a/public/js/ping-demo.js
+++ b/public/js/ping-demo.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('ping-btn');
+  const out = document.getElementById('ping-result');
+  if (btn && out) {
+    btn.addEventListener('click', async () => {
+      out.textContent = 'Loading...';
+      try {
+        const res = await fetch('/api/ping');
+        if (!res.ok) throw new Error(res.status);
+        const data = await res.json();
+        out.textContent = JSON.stringify(data);
+      } catch (err) {
+        out.textContent = 'Error';
+      }
+    });
+  }
+});

--- a/public/js/theme-demo.js
+++ b/public/js/theme-demo.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.theme-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const theme = btn.dataset.theme;
+      document.body.setAttribute('data-theme', theme);
+      const frame = document.querySelector('iframe.giscus-frame');
+      if (frame) {
+        frame.contentWindow.postMessage({
+          giscus: { setConfig: { theme } }
+        }, 'https://giscus.app');
+      }
+      btn.blur();
+    });
+  });
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -25,6 +25,22 @@ header h1 a { text-decoration: none; color: inherit; }
 .post h1 { margin-bottom: 0; }
 .meta { color: var(--muted); margin-top: .25rem; }
 .post-cover { width: 100%; max-height: 360px; object-fit: cover; border-radius: 8px; margin: 0 0 .75rem; display: block; }
+.post img { max-width: 100%; height: auto; }
+.theme-btn {
+  cursor: pointer;
+  background: var(--bg);
+  color: inherit;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: .15rem .5rem;
+}
+.theme-btn:hover {
+  border-color: var(--text);
+}
+.theme-btn:focus {
+  outline: none;
+  border-color: var(--text);
+}
 .post-list { list-style: none; padding: 0; }
 .post-list li { margin: .5rem 0; }
 fieldset { border: 1px solid var(--border); }

--- a/src/posts/asciidoc-adventures.adoc
+++ b/src/posts/asciidoc-adventures.adoc
@@ -1,5 +1,6 @@
 = AsciiDoc Adventures: The Sequel
 :page-layout: post.njk
+:page-date: 2024-02-01
 :author: Doc Tester
 :github: hubot
 :image: https://images.unsplash.com/photo-1504384308090-c894fdcc538d?w=1200&q=80&auto=format&fit=crop

--- a/src/posts/feature-tour.adoc
+++ b/src/posts/feature-tour.adoc
@@ -1,0 +1,151 @@
+= Framework Feature Tour
+:page-layout: post.njk
+:page-date: 2024-03-01
+:toc:
+:author: Josh Kurz
+:github: joshkurz
+:image: https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?w=1200&q=80&auto=format&fit=crop
+:description: An in-depth walkthrough demonstrating every core feature of fast-adoc-blog with hands-on examples.
+:page-tags: features, guide
+
+Welcome to the feature tour. This post demonstrates the goodies available when writing in fast-adoc-blog.
+
+== AsciiDoc Basics
+
+Inline formatting like *bold*, _italic_, and `mono` works out of the box. Attributes at the top control metadata and layout.
+
+== Lists & Tables
+
+. Ordered list item
+.. Nested item
+
+* Unordered list
+* Another item
+
+[cols="1,1",options="header"]
+|===
+|Column A |Column B
+|A1 |B1
+|A2 |B2
+|===
+
+== Code Blocks & Callouts
+
+[source,js]
+----
+function hello(name) {
+  return `Hello, ${name}`; // <1>
+}
+----
+<1> Callouts annotate lines of code.
+
+== Admonitions
+
+[NOTE]
+====
+Use built-in admonitions for tips and warnings.
+====
+
+[TIP]
+====
+Mix multiple admonition types to draw attention to key information.
+====
+
+== Images
+
+image::https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=800&q=80&auto=format&fit=crop[Alt text,width=100%]
+
+== Custom Scripts & APIs
+
+This demo fetches a serverless function using a custom script.
+
+[source,js]
+----
+// api/ping.js
+export default () =>
+  new Response(JSON.stringify({ ok: true }), {
+    headers: { "content-type": "application/json" }
+  });
+----
+
+++++
+<div id="ping-area">
+  <button id="ping-btn">Ping serverless</button>
+  <pre id="ping-result"></pre>
+</div>
+<script type="module" src="/js/ping-demo.js"></script>
+++++
+
+== Theme Options
+
+CSS variables are mapped to giscus theme names. Click a theme to preview it locally—the giscus widget follows suit. Set `theme` in `config.json` to persist a choice.
+
+|===
+|CSS `data-theme` | Matches giscus theme
+
+|+++<button class="theme-btn" data-theme="light">light</button>+++ |`light`
+|+++<button class="theme-btn" data-theme="light_high_contrast">light_high_contrast</button>+++ |`light_high_contrast`
+|+++<button class="theme-btn" data-theme="dark">dark</button>+++ |`dark`
+|+++<button class="theme-btn" data-theme="dark_dimmed">dark_dimmed</button>+++ |`dark_dimmed`
+|+++<button class="theme-btn" data-theme="noborder_dark">noborder_dark</button>+++ |`noborder_dark`
+|+++<button class="theme-btn" data-theme="preferred_color_scheme">preferred_color_scheme</button>+++ |Follows OS preference
+|===
+
++++
+<script type="module" src="/js/theme-demo.js"></script>
++++
+
+== Feature Summary
+
+[options="header"]
+|===
+|Feature |What it shows
+|Responsive images |`image::` macros stretch to fit the container
+|Live theme preview |Buttons swap CSS and giscus themes
+|Serverless ping demo |JS fetches `/api/ping` and prints JSON
+|Comments |Each post maps to a giscus discussion
+|===
+
+== Simple Config
+
+Configuration lives in a single JSON file:
+
+[source,json]
+----
+{
+  "theme": "transparent_dark",
+  "commentsProvider": "giscus",
+  "giscus": {
+    "mapping": "pathname",
+    "theme": "noborder_dark"
+  }
+}
+----
+
+== Deploy & License
+
+Push to GitHub and Vercel builds the site instantly. The project ships under the MIT license—fork freely.
+
+== Comments
+
+The giscus widget below maps each post to a matching GitHub discussion.
+
+To enable comments on your own blog, run `npm run dev` and open pass:[/<wbr>setup]. Paste the giscus script from https://giscus.app into the form and it will write a `config.json` like:
+
+[source,json]
+----
+{
+  "commentsProvider": "giscus",
+  "giscus": {
+    "repo": "youruser/yourrepo",
+    "repoId": "YOUR_REPO_ID",
+    "category": "General",
+    "categoryId": "YOUR_CATEGORY_ID",
+    "mapping": "pathname",
+    "theme": "noborder_dark"
+  }
+}
+----
+
+Commit that file and rebuild—each post will then show its own discussion thread.
+

--- a/src/posts/hello.adoc
+++ b/src/posts/hello.adoc
@@ -1,5 +1,6 @@
 = Hello, AsciiDoc (Now With Dad Jokes)
 :page-layout: post.njk
+:page-date: 2024-01-01
 :toc:
 :author: Ascii Dad
 :image: https://images.unsplash.com/photo-1522075469751-3a6694fb2f61?w=1200&q=80&auto=format&fit=crop


### PR DESCRIPTION
## Summary
- sort Eleventy AsciiDoc posts so the newest articles surface first
- flesh out feature tour with header tables, tip admonitions, and a bottom-placed comments section
- explain how to enable giscus comments via local setup page and config snippet
- preserve original publish dates by reading :page-date: attributes and setting explicit dates for existing posts

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3976a10c88328bc40df93d502b4b1